### PR TITLE
Fix web demo

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -2,5 +2,5 @@ Instructions:
 
 1. Run ```npm install``` in this dir
 2. Run ```node app``` to start a webserver on port 3000
-3. Browse to http://localhost:3000/static/test.html
+3. Browse to http://localhost:3000/test.html
 

--- a/web/static/test.html
+++ b/web/static/test.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
-		<script type="text/javascript" src="/static/spectrum/spectrum.js"></script>
-		<link rel='stylesheet' href='/static/spectrum/spectrum.css' />
+		<script type="text/javascript" src="/spectrum/spectrum.js"></script>
+		<link rel='stylesheet' href='/spectrum/spectrum.css' />
 	</head>
 	<body>
 		<div id="bulb1"></div>


### PR DESCRIPTION
I'm still figuring out express, but it looks like the line
`app.use('/', express.static(__dirname + '/static'));` automatically
prepends "/static" to all URL paths so the "/static" that's currently
in the URLs is incorrect.
