### PR TITLE
minor hsl fixes in web example

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -6,10 +6,10 @@ app.use('/', express.static(__dirname + '/static'));
 
 app.get('/set/bulb1', function(req, res, next) {
 	var bulb1 = req.query.bulb1;
-	// scale it
-	var hue = bulb1.h * (65536 / 360)
-	var sat = bulb1.s * (65536 / 0.8)
-	var lum = bulb1.l * (65536 / 1)
+	// scale and cast to int
+	var hue = parseInt(bulb1.h * (0xffff / 360))
+	var sat = parseInt(bulb1.s * 0xffff)
+	var lum = parseInt(bulb1.l * 0xffff)
 	//console.log(hue, sat, lum);
 	lx.lightsColour(hue, sat, lum, 0x0dac, 0);
 	res.end("OK");


### PR DESCRIPTION
this tweak fixes a couple issues I was having:
- Buffer.writeUInt16LE() was throwing out-of-bounds error when it encounters fractional  hsl values. 
- I think maybe the intent was to cap saturation at 80%, but instead it was being scaled to 120% (causing overflow).
