### PR TITLE
cli2: fix gateway ip parameter

### DIFF
--- a/cli2.js
+++ b/cli2.js
@@ -17,7 +17,7 @@ lx.on('bulb', function(b) {
 	console.log('New bulb found: ' + b.name);
 });
 lx.on('gateway', function(g) {
-	console.log('New gateway found: ' + g.ipAddress.ip);
+	console.log('New gateway found: ' + g.ip);
 });
 
 console.log("Keys:");


### PR DESCRIPTION
The gateways seems to have changed their available parameters,
and IP addresses are now accessed via the gateway.ip property.
